### PR TITLE
adpat libgit2 1.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </properties>
     <groupId>com.github.git24j</groupId>
     <artifactId>git24j</artifactId>
-    <version>1.0.4.20241114</version>
+    <version>1.9.0</version>
     <packaging>jar</packaging>
     <name>git24j</name>
     <description>A java bindings of the libgit2 project.</description>

--- a/src/main/c/git24j/j_blame.c
+++ b/src/main/c/git24j/j_blame.c
@@ -10,10 +10,24 @@ extern j_constants_t *jniConstants;
 
 /** -------- Wrapper Body ---------- */
 /** int git_blame_init_options(git_blame_options *opts, unsigned int version); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniInitOptions)(JNIEnv *env, jclass obj, jlong optsPtr, jint version)
+//JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniInitOptions)(JNIEnv *env, jclass obj, jlong optsPtr, jint version)
+//{
+//    int r = git_blame_init_options((git_blame_options *)optsPtr, version);
+//    return r;
+//}
+
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniOptionsNew)(JNIEnv *env, jclass obj, jobject outPtr, jint version)
 {
-    int r = git_blame_init_options((git_blame_options *)optsPtr, version);
-    return r;
+    git_blame_options *opts = (git_blame_options *)malloc(sizeof(git_blame_options));
+
+    //value of `err`: Zero on success; -1 on failure.
+    // I am not sure it can get this err msg from git_last_err(), if version bad, maybe can get, if mem alloc err, maybe can't
+    int initErr = git_blame_init_options(opts, (unsigned int)version);
+
+    // this set no check the initErr, even initErr, still set the ptr to java pointer, it make java be able free the mallocated memory
+    (*env)->CallVoidMethod(env, outPtr, jniConstants->midAtomicLongSet, (jlong)opts);
+
+    return initErr;
 }
 
 /** size_t git_blame_get_hunk_count(git_blame *blame); */

--- a/src/main/c/git24j/j_blame.h
+++ b/src/main/c/git24j/j_blame.h
@@ -10,8 +10,8 @@ extern "C"
 #endif
 
     /** int git_blame_init_options(git_blame_options *opts, unsigned int version); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniInitOptions)(JNIEnv *env, jclass obj, jlong optsPtr, jint version);
-    JNIEXPORT void JNICALL J_MAKE_METHOD(Blame_jniOptionsNew)(JNIEnv *env, jclass obj, jobject outPtr, jint version);
+//    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniInitOptions)(JNIEnv *env, jclass obj, jlong optsPtr, jint version);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniOptionsNew)(JNIEnv *env, jclass obj, jobject outPtr, jint version);
 
     /** size_t git_blame_get_hunk_count(git_blame *blame); */
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Blame_jniGetHunkCount)(JNIEnv *env, jclass obj, jlong blamePtr);

--- a/src/main/c/git24j/j_packbuilder.c
+++ b/src/main/c/git24j/j_packbuilder.c
@@ -21,7 +21,7 @@ int j_packbuilder_git_indexer_progress_cb(const git_indexer_progress *stats, voi
 }
 
 /** int git_packbuilder_new(git_packbuilder **out, git_repository *repo); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniNew)(JNIEnv *env, jclass obj, jobject out, jlong repoPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniNew)(JNIEnv *env, jclass obj, jobject out, jlong repoPtr)
 {
     git_packbuilder *c_out;
     int r = git_packbuilder_new(&c_out, (git_repository *)repoPtr);
@@ -31,14 +31,14 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniNew)(JNIEnv *env, jclass obj
 }
 
 /** unsigned int git_packbuilder_set_threads(git_packbuilder *pb, unsigned int n); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniSetThreads)(JNIEnv *env, jclass obj, jlong pbPtr, jint n)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniSetThreads)(JNIEnv *env, jclass obj, jlong pbPtr, jint n)
 {
     unsigned int r = git_packbuilder_set_threads((git_packbuilder *)pbPtr, n);
     return r;
 }
 
 /** int git_packbuilder_insert(git_packbuilder *pb, const git_oid *id, const char *name); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsert)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsert)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name)
 {
     git_oid c_id;
     j_git_oid_from_java(env, id, &c_id);
@@ -49,7 +49,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsert)(JNIEnv *env, jclass 
 }
 
 /** int git_packbuilder_insert_tree(git_packbuilder *pb, const git_oid *id); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertTree)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertTree)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id)
 {
     git_oid c_id;
     j_git_oid_from_java(env, id, &c_id);
@@ -58,7 +58,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertTree)(JNIEnv *env, jcl
 }
 
 /** int git_packbuilder_insert_commit(git_packbuilder *pb, const git_oid *id); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertCommit)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertCommit)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id)
 {
     git_oid c_id;
     j_git_oid_from_java(env, id, &c_id);
@@ -67,14 +67,14 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertCommit)(JNIEnv *env, j
 }
 
 /** int git_packbuilder_insert_walk(git_packbuilder *pb, git_revwalk *walk); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertWalk)(JNIEnv *env, jclass obj, jlong pbPtr, jlong walkPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertWalk)(JNIEnv *env, jclass obj, jlong pbPtr, jlong walkPtr)
 {
     int r = git_packbuilder_insert_walk((git_packbuilder *)pbPtr, (git_revwalk *)walkPtr);
     return r;
 }
 
 /** int git_packbuilder_insert_recur(git_packbuilder *pb, const git_oid *id, const char *name); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertRecur)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertRecur)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name)
 {
     git_oid c_id;
     j_git_oid_from_java(env, id, &c_id);
@@ -85,7 +85,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertRecur)(JNIEnv *env, jc
 }
 
 /** int git_packbuilder_write_buf(git_buf *buf, git_packbuilder *pb); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWriteBuf)(JNIEnv *env, jclass obj, jobject buf, jlong pbPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniWriteBuf)(JNIEnv *env, jclass obj, jobject buf, jlong pbPtr)
 {
     git_buf c_buf = {0};
     int r = git_packbuilder_write_buf(&c_buf, (git_packbuilder *)pbPtr);
@@ -95,7 +95,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWriteBuf)(JNIEnv *env, jclas
 }
 
 /** int git_packbuilder_write(git_packbuilder *pb, const char *path, unsigned int mode, git_indexer_progress_cb * progress_cb); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWrite)(JNIEnv *env, jclass obj, jlong pbPtr, jstring path, jint mode, jobject progressCb)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniWrite)(JNIEnv *env, jclass obj, jlong pbPtr, jstring path, jint mode, jobject progressCb)
 {
     int r;
     char *c_path = j_copy_of_jstring(env, path, true);
@@ -115,7 +115,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWrite)(JNIEnv *env, jclass o
 }
 
 /** const git_oid * git_packbuilder_hash(git_packbuilder *pb); */
-JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(Packbuilder_jniHash)(JNIEnv *env, jclass obj, jlong pbPtr)
+JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(PackBuilder_jniHash)(JNIEnv *env, jclass obj, jlong pbPtr)
 {
     const git_oid *r = git_packbuilder_hash((git_packbuilder *)pbPtr);
     return j_git_oid_to_bytearray(env, r);
@@ -136,7 +136,7 @@ int j_git_packbuilder_foreach_cb(void *buf, size_t size, void *payload)
 }
 
 /** int git_packbuilder_foreach(git_packbuilder *pb, git_packbuilder_foreach_cb * cb); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniForeach)(JNIEnv *env, jclass obj, jlong pbPtr, jobject foreachCb)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniForeach)(JNIEnv *env, jclass obj, jlong pbPtr, jobject foreachCb)
 {
     j_cb_payload payload = {0};
     j_cb_payload_init(env, &payload, foreachCb, "([B)I");
@@ -146,14 +146,14 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniForeach)(JNIEnv *env, jclass
 }
 
 /** size_t git_packbuilder_object_count(git_packbuilder *pb); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniObjectCount)(JNIEnv *env, jclass obj, jlong pbPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniObjectCount)(JNIEnv *env, jclass obj, jlong pbPtr)
 {
     size_t r = git_packbuilder_object_count((git_packbuilder *)pbPtr);
     return r;
 }
 
 /** size_t git_packbuilder_written(git_packbuilder *pb); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWritten)(JNIEnv *env, jclass obj, jlong pbPtr)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniWritten)(JNIEnv *env, jclass obj, jlong pbPtr)
 {
     size_t r = git_packbuilder_written((git_packbuilder *)pbPtr);
     return r;
@@ -172,7 +172,7 @@ int j_git_packbuilder_progress(int stage, uint32_t current, uint32_t total, void
 }
 
 /** int git_packbuilder_set_callbacks(git_packbuilder *pb, git_packbuilder_progress * progress_cb); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniSetCallbacks)(JNIEnv *env, jclass obj, jlong pbPtr, jobject progressCb)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniSetCallbacks)(JNIEnv *env, jclass obj, jlong pbPtr, jobject progressCb)
 {
     j_cb_payload *payload = (j_cb_payload *)malloc(sizeof(j_cb_payload));
     j_cb_payload_init(env, payload, progressCb, "(III)I");
@@ -181,7 +181,7 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniSetCallbacks)(JNIEnv *env, j
 }
 
 /** void git_packbuilder_free(git_packbuilder *pb); */
-JNIEXPORT void JNICALL J_MAKE_METHOD(Packbuilder_jniFree)(JNIEnv *env, jclass obj, jlong pbPtr)
+JNIEXPORT void JNICALL J_MAKE_METHOD(PackBuilder_jniFree)(JNIEnv *env, jclass obj, jlong pbPtr)
 {
     git_packbuilder_free((git_packbuilder *)pbPtr);
 }

--- a/src/main/c/git24j/j_packbuilder.h
+++ b/src/main/c/git24j/j_packbuilder.h
@@ -10,49 +10,49 @@ extern "C"
 #endif
 
     /** int git_packbuilder_new(git_packbuilder **out, git_repository *repo); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniNew)(JNIEnv *env, jclass obj, jobject out, jlong repoPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniNew)(JNIEnv *env, jclass obj, jobject out, jlong repoPtr);
 
     /** unsigned int git_packbuilder_set_threads(git_packbuilder *pb, unsigned int n); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniSetThreads)(JNIEnv *env, jclass obj, jlong pbPtr, jint n);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniSetThreads)(JNIEnv *env, jclass obj, jlong pbPtr, jint n);
 
     /** int git_packbuilder_insert(git_packbuilder *pb, const git_oid *id, const char *name); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsert)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsert)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name);
 
     /** int git_packbuilder_insert_tree(git_packbuilder *pb, const git_oid *id); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertTree)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertTree)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id);
 
     /** int git_packbuilder_insert_commit(git_packbuilder *pb, const git_oid *id); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertCommit)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertCommit)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id);
 
     /** int git_packbuilder_insert_walk(git_packbuilder *pb, git_revwalk *walk); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertWalk)(JNIEnv *env, jclass obj, jlong pbPtr, jlong walkPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertWalk)(JNIEnv *env, jclass obj, jlong pbPtr, jlong walkPtr);
 
     /** int git_packbuilder_insert_recur(git_packbuilder *pb, const git_oid *id, const char *name); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniInsertRecur)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniInsertRecur)(JNIEnv *env, jclass obj, jlong pbPtr, jobject id, jstring name);
 
     /** int git_packbuilder_write_buf(git_buf *buf, git_packbuilder *pb); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWriteBuf)(JNIEnv *env, jclass obj, jobject buf, jlong pbPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniWriteBuf)(JNIEnv *env, jclass obj, jobject buf, jlong pbPtr);
 
     /** int git_packbuilder_write(git_packbuilder *pb, const char *path, unsigned int mode, git_indexer_progress_cb * progress_cb); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWrite)(JNIEnv *env, jclass obj, jlong pbPtr, jstring path, jint mode, jobject progressCb);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniWrite)(JNIEnv *env, jclass obj, jlong pbPtr, jstring path, jint mode, jobject progressCb);
 
     /** const git_oid * git_packbuilder_hash(git_packbuilder *pb); */
-    JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(Packbuilder_jniHash)(JNIEnv *env, jclass obj, jlong pbPtr);
+    JNIEXPORT jbyteArray JNICALL J_MAKE_METHOD(PackBuilder_jniHash)(JNIEnv *env, jclass obj, jlong pbPtr);
 
     /** int git_packbuilder_foreach(git_packbuilder *pb, git_packbuilder_foreach_cb * cb); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniForeach)(JNIEnv *env, jclass obj, jlong pbPtr, jobject foreachCb);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniForeach)(JNIEnv *env, jclass obj, jlong pbPtr, jobject foreachCb);
 
     /** size_t git_packbuilder_object_count(git_packbuilder *pb); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniObjectCount)(JNIEnv *env, jclass obj, jlong pbPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniObjectCount)(JNIEnv *env, jclass obj, jlong pbPtr);
 
     /** size_t git_packbuilder_written(git_packbuilder *pb); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniWritten)(JNIEnv *env, jclass obj, jlong pbPtr);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniWritten)(JNIEnv *env, jclass obj, jlong pbPtr);
 
     /** int git_packbuilder_set_callbacks(git_packbuilder *pb, git_packbuilder_progress * progress_cb); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Packbuilder_jniSetCallbacks)(JNIEnv *env, jclass obj, jlong pbPtr, jobject progressCb);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(PackBuilder_jniSetCallbacks)(JNIEnv *env, jclass obj, jlong pbPtr, jobject progressCb);
 
     /** void git_packbuilder_free(git_packbuilder *pb); */
-    JNIEXPORT void JNICALL J_MAKE_METHOD(Packbuilder_jniFree)(JNIEnv *env, jclass obj, jlong pbPtr);
+    JNIEXPORT void JNICALL J_MAKE_METHOD(PackBuilder_jniFree)(JNIEnv *env, jclass obj, jlong pbPtr);
 
 #ifdef __cplusplus
 }

--- a/src/main/c/git24j/j_rebase.h
+++ b/src/main/c/git24j/j_rebase.h
@@ -94,6 +94,8 @@ extern "C"
     /** git_commit_signing_cb signing_cb*/
     JNIEXPORT void JNICALL J_MAKE_METHOD(Rebase_jniOptionsSetSigningCb)(JNIEnv *env, jclass obj, jlong optionsPtr, jobject signingCb);
 
+    JNIEXPORT void JNICALL J_MAKE_METHOD(Rebase_jniOptionsSetPayload)(JNIEnv *env, jclass obj, jlong optionsPtr, jlong payload);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/main/c/git24j/j_remote.c
+++ b/src/main/c/git24j/j_remote.c
@@ -443,9 +443,9 @@ JNIEXPORT jlong JNICALL J_MAKE_METHOD(Remote_jniGetRefspec)(JNIEnv *env, jclass 
 }
 
 /** int git_remote_init_callbacks(git_remote_callbacks *opts, unsigned int version); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniInitCallbacks)(JNIEnv *env, jclass obj, jlong optsPtr, jint version)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniInitCallbacks)(JNIEnv *env, jclass obj, jlong remoteCallbacksPtr, jint version)
 {
-    int r = git_remote_init_callbacks((git_remote_callbacks *)optsPtr, version);
+    int r = git_remote_init_callbacks((git_remote_callbacks *)remoteCallbacksPtr, version);
     return r;
 }
 

--- a/src/main/c/git24j/j_remote.h
+++ b/src/main/c/git24j/j_remote.h
@@ -80,7 +80,7 @@ extern "C"
     JNIEXPORT jlong JNICALL J_MAKE_METHOD(Remote_jniGetRefspec)(JNIEnv *env, jclass obj, jlong remotePtr, jint n);
 
     /** int git_remote_init_callbacks(git_remote_callbacks *opts, unsigned int version); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniInitCallbacks)(JNIEnv *env, jclass obj, jlong optsPtr, jint version);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniInitCallbacks)(JNIEnv *env, jclass obj, jlong remoteCallbacksPtr, jint version);
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Remote_jniCallbacksNew)(JNIEnv *env, jclass obj, jobject outCb, jint version);
     JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniCallbacksFree)(JNIEnv *env, jclass obj, jlong cbsPtr);
     JNIEXPORT void JNICALL J_MAKE_METHOD(Remote_jniCallbacksTest)(JNIEnv *env, jclass obj, jlong cbsPtr, jobject cbsObject);

--- a/src/main/c/git24j/j_submodule.c
+++ b/src/main/c/git24j/j_submodule.c
@@ -258,9 +258,9 @@ JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdate)(JNIEnv *env, jclass ob
 }
 
 /** int git_submodule_update_init_options(git_submodule_update_options *opts, unsigned int version); */
-JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdateInitOptions)(JNIEnv *env, jclass obj, jlong optsPtr, jint version)
+JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdateInitOptions)(JNIEnv *env, jclass obj, jlong updateOptionsPtr, jint version)
 {
-    int r = git_submodule_update_init_options((git_submodule_update_options *)optsPtr, version);
+    int r = git_submodule_update_init_options((git_submodule_update_options *)updateOptionsPtr, version);
     return r;
 }
 

--- a/src/main/c/git24j/j_submodule.h
+++ b/src/main/c/git24j/j_submodule.h
@@ -99,7 +99,7 @@ extern "C"
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdate)(JNIEnv *env, jclass obj, jlong submodulePtr, jint init, jlong optionsPtr);
 
     /** int git_submodule_update_init_options(git_submodule_update_options *opts, unsigned int version); */
-    JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdateInitOptions)(JNIEnv *env, jclass obj, jlong optsPtr, jint version);
+    JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdateInitOptions)(JNIEnv *env, jclass obj, jlong updateOptionsPtr, jint version);
     JNIEXPORT jint JNICALL J_MAKE_METHOD(Submodule_jniUpdateOptionsNew)(JNIEnv *env, jclass obj, jobject outOpt, jint version);
     /** git_checkout_options *checkout_opts*/
     JNIEXPORT jlong JNICALL J_MAKE_METHOD(Submodule_jniUpdateOptionsGetCheckoutOpts)(JNIEnv *env, jclass obj, jlong updateOptionsPtr);

--- a/src/main/java/com/github/git24j/core/Blame.java
+++ b/src/main/java/com/github/git24j/core/Blame.java
@@ -57,10 +57,8 @@ public class Blame extends CAutoReleasable {
     /** size_t orig_start_line_number */
     static native int jniHunkGetOrigStartLineNumber(long hunkPtr);
 
-    /** int git_blame_init_options(git_blame_options *opts, unsigned int version); */
-    static native int jniInitOptions(long opts, int version);
-
-    static native void jniOptionsNew(AtomicLong outPtr, int version);
+    // return is the errcode, not 0 means err
+    static native int jniOptionsNew(AtomicLong outPtr, int version);
 
     protected Blame(boolean isWeak, long rawPtr) {
         super(isWeak, rawPtr);
@@ -169,7 +167,11 @@ public class Blame extends CAutoReleasable {
          * names and email addresses. The mailmap will be read from the working directory, or HEAD
          * in a bare repository.
          */
-        USE_MAILMAP(1 << 5);
+        USE_MAILMAP(1 << 5),
+
+        /** Ignore whitespace differences */
+        IGNORE_WHITESPACE(1 << 6);
+
         private final int _bit;
 
         FlagT(int bit) {
@@ -189,9 +191,9 @@ public class Blame extends CAutoReleasable {
             super(isWeak, rawPtr);
         }
 
-        public static Options init(int version) {
+        public static Options create(int version) {
             Options out = new Options(false, 0);
-            jniOptionsNew(out._rawPtr, version);
+            Error.throwIfNeeded(jniOptionsNew(out._rawPtr, version));
             return out;
         }
 

--- a/src/main/java/com/github/git24j/core/Blob.java
+++ b/src/main/java/com/github/git24j/core/Blob.java
@@ -144,7 +144,7 @@ public class Blob extends GitObject {
      * instead.
      *
      * @param repo git repo
-     * @param oid sha of the blob to search.
+     * @param shortId oid sha of the blob to search.
      * @return found blob or null
      * @throws GitException git error
      */

--- a/src/main/java/com/github/git24j/core/Checkout.java
+++ b/src/main/java/com/github/git24j/core/Checkout.java
@@ -216,11 +216,9 @@ public class Checkout {
     }
 
     public enum StrategyT implements IBitEnum {
-        /** default is a dry run, no actual updates */
-        NONE(0),
-
         /** Allow safe updates that cannot overwrite uncommitted data */
-        SAFE(1 << 0),
+        // updated from 1 to 0, since libgit2 1.9.0
+        SAFE(0),
 
         /** Allow all updates to force working directory to look like index */
         FORCE(1 << 1),
@@ -276,10 +274,39 @@ public class Checkout {
 
         /** Normally checkout writes the index upon completion; this prevents that. */
         DONT_WRITE_INDEX(1 << 23),
+
+
+        /**
+         * Perform a "dry run", reporting what _would_ be done but
+         * without actually making changes in the working directory
+         * or the index.
+         */
+        DRY_RUN(1 << 24),
+
+        /** Include common ancestor data in zdiff3 format for conflicts */
+        CONFLICT_STYLE_ZDIFF3(1 << 25),
+
+        /**
+         * Do not do a checkout and do not fire callbacks; this is primarily
+         * useful only for internal functions that will perform the
+         * checkout themselves but need to pass checkout options into
+         * another function, for example, `git_clone`.
+        */
+        NONE(1 << 30),
+
+
+        /*
+         * THE FOLLOWING OPTIONS ARE NOT YET IMPLEMENTED
+         */
+
+
         /** Recursively checkout submodules with same options (NOT IMPLEMENTED) */
         UPDATE_SUBMODULES(1 << 16),
+
         /** Recursively checkout submodules if HEAD moved in super repo (NOT IMPLEMENTED) */
         UPDATE_SUBMODULES_IF_CHANGED(1 << 17);
+
+
         private final int _bit;
 
         StrategyT(int bit) {

--- a/src/main/java/com/github/git24j/core/Config.java
+++ b/src/main/java/com/github/git24j/core/Config.java
@@ -799,7 +799,10 @@ public class Config extends CAutoReleasable {
 
         @Override
         protected void freeOnce(long cPtr) {
-            jniEntryFree(cPtr);
+
+            // libgit2 1.9.0 say: "end-users should not try to free that structure"
+            // see: https://github.com/libgit2/libgit2/releases/tag/v1.9.0 , section "Breaking changes", sub section "Configuration entry member removal (ABI breaking change)"
+            // jniEntryFree(cPtr);
         }
 
         public String getName() {

--- a/src/main/java/com/github/git24j/core/Cred.java
+++ b/src/main/java/com/github/git24j/core/Cred.java
@@ -8,8 +8,7 @@ public class Cred extends CAutoReleasable {
      * int git_cred_acquire_cb(git_cred **cred, const char *url, const char *username_from_url,
      * unsigned int allowed_types, void *payload);
      */
-    static native int jniAcquireCb(
-            AtomicLong cred, String url, String usernameFromUrl, int allowedTypes);
+//    static native int jniAcquireCb( AtomicLong cred, String url, String usernameFromUrl, int allowedTypes);
 
     /** int git_cred_default_new(git_cred **out); */
     static native int jniDefaultNew(AtomicLong out);
@@ -52,8 +51,7 @@ public class Cred extends CAutoReleasable {
      * int git_cred_userpass(git_cred **cred, const char *url, const char *user_from_url, unsigned
      * int allowed_types, void *payload);
      */
-    static native int jniUserpass(
-            AtomicLong cred, String url, String userFromUrl, int allowedTypes);
+//    static native int jniUserpass( AtomicLong cred, String url, String userFromUrl, int allowedTypes);
 
     /**
      * int git_cred_userpass_plaintext_new(git_cred **out, const char *username, const char

--- a/src/main/java/com/github/git24j/core/PackBuilder.java
+++ b/src/main/java/com/github/git24j/core/PackBuilder.java
@@ -5,6 +5,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class PackBuilder extends CAutoReleasable {
+
     /** int git_packbuilder_foreach(git_packbuilder *pb, git_packbuilder_foreach_cb * cb); */
     static native int jniForeach(long pb, Internals.BArrCallback cb);
 

--- a/src/main/java/com/github/git24j/core/Rebase.java
+++ b/src/main/java/com/github/git24j/core/Rebase.java
@@ -8,6 +8,9 @@ import javax.annotation.Nullable;
 
 public class Rebase extends CAutoReleasable {
 
+        /** void *payload */
+    static native void jniOptionsSetPayload(long optionsPtr, long payload);
+
     /** int git_rebase_abort(git_rebase *rebase); */
     static native int jniAbort(long rebase);
 
@@ -394,9 +397,6 @@ public class Rebase extends CAutoReleasable {
      */
     public static class Options extends CAutoReleasable {
         public static final int VERSION = 1;
-
-        /** void *payload */
-        static native void jniOptionsSetPayload(long optionsPtr, long payload);
 
         protected Options(boolean isWeak, long rawPtr) {
             super(isWeak, rawPtr);

--- a/src/main/java/com/github/git24j/core/Reflog.java
+++ b/src/main/java/com/github/git24j/core/Reflog.java
@@ -48,7 +48,7 @@ public class Reflog extends CAutoReleasable {
      * int git_transaction_set_reflog(git_transaction *tx, const char *refname, const git_reflog
      * *reflog);
      */
-    static native int jniSetReflog(long tx, String refname, long reflog);
+//    static native int jniSetReflog(long tx, String refname, long reflog);
 
     /** int git_reflog_write(git_reflog *reflog); */
     static native int jniWrite(long reflog);
@@ -90,9 +90,9 @@ public class Reflog extends CAutoReleasable {
         return reflog;
     }
 
-    public void transactionSetReflog(@Nonnull Transaction tx, @Nonnull String refname) {
-        Error.throwIfNeeded(jniSetReflog(tx.getRawPointer(), refname, getRawPointer()));
-    }
+//    public void transactionSetReflog(@Nonnull Transaction tx, @Nonnull String refname) {
+//        Error.throwIfNeeded(jniSetReflog(tx.getRawPointer(), refname, getRawPointer()));
+//    }
 
     public void write() {
         Error.throwIfNeeded(jniWrite(getRawPointer()));

--- a/src/main/java/com/github/git24j/core/Remote.java
+++ b/src/main/java/com/github/git24j/core/Remote.java
@@ -168,7 +168,10 @@ public class Remote extends CAutoReleasable {
     static native int jniFetchOptionsNew(AtomicLong outPtr, int version);
 
     /** git_remote_callbacks callbacks */
-    static native void jniFetchOptionsSetCallbacks(long fetch_optionsPtr, Callbacks callbacks);
+//    static native void jniFetchOptionsSetCallbacks(long fetch_optionsPtr, Callbacks callbacks);
+
+    /** git_remote_init_callbacks */
+    static native int jniInitCallbacks(long remoteCallbacksPtr, int version);
 
     /** git_strarray custom_headers */
     static native void jniFetchOptionsSetCustomHeaders(

--- a/src/main/java/com/github/git24j/core/Submodule.java
+++ b/src/main/java/com/github/git24j/core/Submodule.java
@@ -143,7 +143,10 @@ public class Submodule extends CAutoReleasable {
     static native void jniUpdateOptionsSetAllowFetch(long update_optionsPtr, int allowFetch);
 
     /** git_checkout_options *checkout_opts */
-    static native void jniUpdateOptionsSetCheckoutOpts(long update_optionsPtr, long checkoutOpts);
+//    static native void jniUpdateOptionsSetCheckoutOpts(long update_optionsPtr, long checkoutOpts);
+
+    /** git_submodule_update_init_options */
+    static native int jniUpdateInitOptions(long updateOptionsPtr, int version);
 
     /** git_submodule_update_t git_submodule_update_strategy(git_submodule *submodule); */
     static native int jniUpdateStrategy(long submodule);


### PR DESCRIPTION
- fix some functions name wrong
- bump git24j version to 1.9.0(same with target libgit2 version)
